### PR TITLE
Fix unsoundness in the crate design

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "static-box"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 
 authors = ["alekseysidorov"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ impl SerialWrite for Uart1Rx {
 }
 let rx = Uart1Rx { /* ... */ };
 
-let mut writer = Box::<dyn SerialWrite, [u8; 32]>::new(rx);
+let mut buf = [0; 32];
+let mut writer = Box::<dyn SerialWrite>::new(&mut buf, rx);
 writer.write_str("Hello world!");
 ```
 


### PR DESCRIPTION
This PR fixes two types of unsoundness:

- `Box::new` relied on the RVO, but the compiler doesn't guarantee this kind of optimization, therefore the memory buffer which stores the `dyn Trait` object can be moved after object construction what can break alignment. In this way, unfortunately,  this PR removes this method.
- `AsRef <[u8]` and  `AsMut <[u8]>` can point to different memory locations, therefore this PR replaces the generic `M` parameter by the plain `&mut [u8]` reference.